### PR TITLE
Collection Lists, Item View Object Area, Slick Carousel Integration

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -107,42 +107,42 @@ $('[data-toggle="tooltip"]').tooltip({
 
 // ##### Slick Carousel ##### //
 
-$('.carousel').slick({
-  infinite: true,
-  speed: 300,
-  // slidesToShow: 12,
-  slidesToScroll: 3,
-  variableWidth: true,
-  responsive: [
-    {
-      breakpoint: 1200,
-      settings: {
-        infinite: true,
-        // slidesToShow: 8,
-        slidesToScroll: 8,
-        variableWidth: true
-      }
-    },
-    {
-      breakpoint: 900,
-      settings: {
-        infinite: true,
-        // slidesToShow: 6,
-        slidesToScroll: 6,
-        variableWidth: true
-      }
-    },
-    {
-      breakpoint: 650,
-      settings: {
-        infinite: true,
-        // slidesToShow: 4,
-        slidesToScroll: 4,
-        variableWidth: true
-      }
-    }
-  ]
-});
+// $('.carousel').slick({
+//   infinite: true,
+//   speed: 300,
+//   // slidesToShow: 12,
+//   slidesToScroll: 3,
+//   variableWidth: true,
+//   responsive: [
+//     {
+//       breakpoint: 1200,
+//       settings: {
+//         infinite: true,
+//         // slidesToShow: 8,
+//         slidesToScroll: 8,
+//         variableWidth: true
+//       }
+//     },
+//     {
+//       breakpoint: 900,
+//       settings: {
+//         infinite: true,
+//         // slidesToShow: 6,
+//         slidesToScroll: 6,
+//         variableWidth: true
+//       }
+//     },
+//     {
+//       breakpoint: 650,
+//       settings: {
+//         infinite: true,
+//         // slidesToShow: 4,
+//         slidesToScroll: 4,
+//         variableWidth: true
+//       }
+//     }
+//   ]
+// });
 
 // Alternative JavaScript method (instead of CSS method) for disabling popover via breakpoint:
 // if (Modernizr.mq('only screen and (max-width: 800px)')) {

--- a/app/scripts/search.js
+++ b/app/scripts/search.js
@@ -368,4 +368,45 @@ FacetQuery.prototype.getValuesFromDom = function() {
 $(document).ready(function() {
   var query = new FacetQuery();
   query.selectDeselectAll();
+  
+  // ##### Slick Carousel ##### //
+
+  $('.carousel').slick({
+    infinite: true,
+    speed: 300,
+    slidesToShow: 10,
+    slidesToScroll: 6,
+    variableWidth: true,
+    lazyLoad: 'ondemand',
+    responsive: [
+      {
+        breakpoint: 1200,
+        settings: {
+          infinite: true,
+          // slidesToShow: 8,
+          slidesToScroll: 8,
+          variableWidth: true
+        }
+      },
+      {
+        breakpoint: 900,
+        settings: {
+          infinite: true,
+          // slidesToShow: 6,
+          slidesToScroll: 6,
+          variableWidth: true
+        }
+      },
+      {
+        breakpoint: 650,
+        settings: {
+          infinite: true,
+          // slidesToShow: 4,
+          slidesToScroll: 4,
+          variableWidth: true
+        }
+      }
+    ]
+  });
+  
 });

--- a/calisphere/templates/calisphere/base.html
+++ b/calisphere/templates/calisphere/base.html
@@ -11,7 +11,6 @@
       <link rel="stylesheet" href="{% static "bower_components/slick.js/slick/slick.css" %}" />
       <link rel="stylesheet" href="{% static "bower_components/fontawesome/css/font-awesome.css" %}" />
       <link rel="stylesheet" href="{% static "bower_components/mediaelement/build/mediaelementplayer.css" %}" />
-      <link rel="stylesheet" href="{% static "bower_components/flickity/css/flickity.css" %}" />
       <link rel="stylesheet" href="{% static "styles/main.css" %}" />
     {% else %}
       <link rel="stylesheet" href="{% static "styles/vendor.css" %}" />
@@ -53,7 +52,6 @@
       <script src="{% static "bower_components/unidragger/unidragger.js" %}"></script>
       <script src="{% static "bower_components/fizzy-ui-utils/utils.js" %}"></script>
       <script src="{% static "bower_components/tap-listener/tap-listener.js" %}"></script>
-      <script src="{% static "bower_components/flickity/dist/flickity.pkgd.js" %}"></script>
     {% else %}
       <script src="{% static "scripts/vendor.js" %}"></script>
       <script src="{% static "scripts/vendor/modernizr.js" %}"></script>

--- a/calisphere/templates/calisphere/carousel.html
+++ b/calisphere/templates/calisphere/carousel.html
@@ -8,12 +8,13 @@
   Displaying {{ start|add:1 }} - {{ start|add:6 }} of {{ numFound }}
 </div>
 
-<div class="carousel js-flickity" data-flickity-options='{ "cellAlign": "left", "contain": true, "pageDots": false, "percentPosition": false }'>
+<div class="carousel">
   
   {% for item in search_results %}
   <div class="carousel__item">
-    <a class="js-item-link" href="{% url 'calisphere:itemView' item.id %}" data-item_id="{{ item.id }}">
-      <img src="{{ thumbnailUrl }}crop/120x120/{{ item.reference_image_md5 }}" alt="{{ item.title.0 }}">
+    <a class="carousel__link js-item-link" href="{% url 'calisphere:itemView' item.id %}" data-item_id="{{ item.id }}">
+      <img data-lazy="{{ thumbnailUrl }}crop/120x120/{{ item.reference_image_md5 }}" alt="{{ item.title.0 }}">
+      <!-- {{ item.reference_image_md5 }} -->
     </a>
     <div class="carousel__thumbnail-caption">{{ item.title.0|truncatewords:7 }}
     </div>
@@ -22,7 +23,7 @@
 
 </div>
 
-<div style="display: none;">
+<!-- <div style="display: none;">
   <div class="col-md-1">
     {% if start|subtract:6 > 0 %}
       <button class="btn btn-link carousel__prev-button js-carousel-page" data-carousel_start="{{ start|subtract:6 }}">
@@ -36,7 +37,7 @@
       </button>
     {% endif %}
   </div>
-  
+
   <div class="col-md-1">
     {% if start|add:6 < numFound %}
       <button class="btn btn-link carousel__next-button js-carousel-page" data-carousel_start="{{ start|add:6 }}">
@@ -45,4 +46,4 @@
       </button>
     {% endif %}
   </div>
-</div>
+</div> -->

--- a/calisphere/templates/calisphere/itemView.html
+++ b/calisphere/templates/calisphere/itemView.html
@@ -12,19 +12,29 @@
   <p class="text__breadcrumb-nav">Search > {{ q }} > {{ item.title.0|truncatewords:7 }}</p>
 
   <h2 class="object__page-heading">{{ item.type.0 }} / <strong>{{ item.title.0|truncatewords:7 }}</strong></h2>
-
-  <div class="object__container-generic">
-    <a class="obj-harvest__link" href="{{ item.url_item }}" target="_blank">
-      <div class="icon__overlay-container">
-        <span class="fa fa-external-link fa-fw obj-harvest__external-link-icon-overlay"></span>
-        <img class="obj-harvest__image" src="{{ thumbnailUrl }}clip/500x500/{{ item.reference_image_md5 }}" alt="">
-      </div>
-      <div class="obj-harvest__caption">Preview. View on contributor's website.
-      </div>
-    </a>
-
-  </div>
-
+  
+  {% if item.structmap_url != '' %}
+    Hey I'm a Complex Object, amy hasn't see one of these before in the index! <br>
+    {{ item.structmap_url }} <br>
+    {{ item.structmap_text }} <br>
+    {{ item.type_ss.0 }} <br>
+  {% endif %} 
+  
+  {% if item.harvest_type.0 == 'harvested' %}
+    {% if item.type_ss.0 == 'image' %}
+      {% include 'calisphere/objectViewer/harvestedImage.html' %}
+    {% else %}
+      {% include 'calisphere/objectViewer/harvestedNonImage.html' %}
+    {% endif %}
+  {% elif item.harvest_type.0 == 'hosted' %}
+    {% if item.type_ss.0 == 'image' %}
+    {% elif item.type_ss.0 == 'moving image' %}
+    {% elif item.type_ss.0 == 'sound' %}
+    {% elif item.type_ss.0 == "text"%}
+    {% elif item.type_ss.0 == "physical object"%}
+    {% endif %}
+  {% endif %}
+  
   <div class="obj-buttons">
 
     <div class="obj-buttons__group1">

--- a/calisphere/templates/calisphere/objectViewer/harvestedImage.html
+++ b/calisphere/templates/calisphere/objectViewer/harvestedImage.html
@@ -1,0 +1,11 @@
+  <div class="object__container-generic">
+    <a class="obj-harvest__link" href="{{ item.url_item }}" target="_blank">
+      <div class="icon__overlay-container">
+        <span class="fa fa-external-link fa-fw obj-harvest__external-link-icon-overlay"></span>
+        <img class="obj-harvest__image" src="{{ thumbnailUrl }}clip/500x500/{{ item.reference_image_md5 }}" alt="">
+      </div>
+      <div class="obj-harvest__caption">Preview. View on contributor's website.
+      </div>
+    </a>
+
+  </div>

--- a/calisphere/templates/calisphere/objectViewer/harvestedNonImage.html
+++ b/calisphere/templates/calisphere/objectViewer/harvestedNonImage.html
@@ -1,0 +1,13 @@
+{% if item.type_ss.0 == 'moving image' %}
+  Video Icon
+{% elif item.type_ss.0 == 'sound' %}
+  Audio Icon
+{% elif item.type_ss.0 == "text"%}
+  Text Icon
+{% elif item.type_ss.0 == "physical object"%}
+  Physical Object Icon
+{% endif %}
+<br>
+<!-- TODO: change 'contributor' to 'OAC' when applicable - will require some logic -->
+Preview unavailable on Calisphere. <a href="{{ item.url_item }}" target="_blank">Play {{ item.typ_ss.0 }} on contributor's website. </a>
+<br><br>

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -471,13 +471,18 @@ def collectionsAZ(request, collection_letter):
             if collection_link.label[0] == collection_letter or collection_link.label[0] == collection_letter.upper():
                 collections_list.append(collection_link)
 
+    page = int(request.GET['page']) if 'page' in request.GET else 0
+    numPages = int(math.ceil(len(collections_list)/10))
+    
     collections = []
-    for collection_link in collections_list:
+    for collection_link in collections_list[page*10:(page*10)+10]:
         collections.append(getCollectionMosaic(collection_link.url))
 
     return render(request, 'calisphere/collectionsAZ.html', {'collections': collections,
         'alphabet': list(string.ascii_uppercase),
-        'collection_letter': collection_letter
+        'collection_letter': collection_letter, 
+        'page': page,
+        'numPages': numPages,
     })
 
 def collectionsSearch(request):
@@ -699,6 +704,8 @@ def campusView(request, campus_slug, subnav=False):
             'campus_slug': campus_slug
         })
     else:
+        page = int(request.GET['page']) if 'page' in request.GET else 0
+        
         campus_fq = ['campus_url: "' + campus_url + '"']
 
         collections_solr_search = SOLR_select(
@@ -709,6 +716,19 @@ def campusView(request, campus_slug, subnav=False):
             facet='true',
             facet_mincount=1,
             facet_limit='-1',
+            facet_field=['collection_data']
+        )
+        
+        numPages = int(math.ceil(len(collections_solr_search.facet_counts['facet_fields']['collection_data'])/10))
+
+        collections_solr_search = SOLR_select(
+            q='',
+            rows=0,
+            start=0,
+            fq=campus_fq,
+            facet='true',
+            facet_mincount=1,
+            facet_limit='10',
             facet_field = ['collection_data', 'repository_data']
         )
 
@@ -720,6 +740,8 @@ def campusView(request, campus_slug, subnav=False):
             related_collections[i] = getCollectionMosaic(collection_data['url'])
 
         return render(request, 'calisphere/campusCollectionsView.html', {
+            'page': page,
+            'numPages': numPages,
             'campus_slug': campus_slug,
             'collections': related_collections,
             'campus': campus_details,
@@ -796,13 +818,15 @@ def repositoryView(request, repository_id, subnav=False):
         })
     
     else:
+        page = int(request.GET['page']) if 'page' in request.GET else 0
+        
         if 'campus' in repository and repository['campus']:
             collections_fq = ['repository_data: "' + repository['url'] + '::' + repository['name'] + '::' + repository['campus'] + '"']
             uc_institution = repository['campus']
         else:
             collections_fq = ['repository_data: "' + repository['url'] + '::' + repository['name'] + '"']
             uc_institution = False
-
+        
         collections_solr_search = SOLR_select(
             q='',
             rows=0,
@@ -811,6 +835,20 @@ def repositoryView(request, repository_id, subnav=False):
             facet='true',
             facet_mincount=1,
             facet_limit='-1',
+            facet_field=['collection_data']
+        )
+        
+        numPages = int(math.ceil(len(collections_solr_search.facet_counts['facet_fields']['collection_data'])/10))
+
+        collections_solr_search = SOLR_select(
+            q='',
+            rows=0,
+            start=0,
+            fq=collections_fq,
+            facet='true',
+            facet_mincount=1,
+            facet_limit='10',
+            facet_offset=page*10,
             facet_field = ['collection_data', 'repository_data']
         )
 
@@ -822,6 +860,8 @@ def repositoryView(request, repository_id, subnav=False):
             related_collections[i] = getCollectionMosaic(collection_data['url'])
 
         return render(request, 'calisphere/repositoryCollectionsView.html', {
+            'page': page,
+            'numPages': numPages,
             'repository_id': repository_id,
             'collections': related_collections,
             'repository': repository_details,

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -220,6 +220,16 @@ def itemView(request, item_id=''):
     if not item_solr_search.numFound:
         raise Http404("{0} does not exist".format(item_id))
 
+    for item in item_solr_search.results:
+        if len(item['collection_url']) >= 1:
+            item['harvest_type'] = []
+            for collection_url in item['collection_url']:
+                collection_details = json_loads_url(collection_url + "?format=json")
+                if (collection_details['harvest_type'] == 'NUX'):
+                    item['harvest_type'].append('hosted')
+                else:
+                    item['harvest_type'].append('harvested')
+
     # TODO: write related objects version (else)
     if request.method == 'GET' and len(request.GET.getlist('q')) > 0:
         queryParams = processQueryRequest(request)


### PR DESCRIPTION
Collection Lists: 
- Only loading the first 10 collections in all collections lists (Random Explore, A-Z, on Institution pages)
- Set up pagination to load more, but don't have it hooked up to infinite scroll yet

Item View: 
- Added logic as well as some stubs for handling different object representations (hosted vs harvested, different types) on Item view

Carousel Integration:
- Integrated the carousel, still need to handle pagination