### PR TITLE
Looped related collections thumbnails

### DIFF
--- a/app/scripts/new-search.js
+++ b/app/scripts/new-search.js
@@ -74,7 +74,8 @@ var FacetForm = Backbone.View.extend({
     'click .js-clear-filters'                 : 'clearFilters',
     'click .js-a-check__header'               : 'toggleFacetDropdown',
     'click .js-a-check__update'               : 'updateFacets',
-    'click .js-rc-page'                       : 'paginateRelatedCollections'
+    'click .js-rc-page'                       : 'paginateRelatedCollections',
+    'click .js-relatedCollection'             : 'goToCollectionPage'
   },
 
   setRefineQuery: function(e) {
@@ -252,6 +253,10 @@ var FacetForm = Backbone.View.extend({
         $('#js-relatedCollections').html(data);
       }
     });
+  },
+
+  goToCollectionPage: function() {
+    this.model.clear();
   },
 
   render: function() {

--- a/app/scripts/new-search.js
+++ b/app/scripts/new-search.js
@@ -324,10 +324,11 @@ var CarouselContext = Backbone.View.extend({
   },
 
   events: {
-    'click #js-linkBack'      : 'goToSearchResults',
-    'beforeChange .carousel'  : 'loadSlides',
-    'click .js-item-link'     : 'goToItemPage',
-    'click .js-rc-page'       : 'paginateRelatedCollections'
+    'click #js-linkBack'             : 'goToSearchResults',
+    'beforeChange .carousel'         : 'loadSlides',
+    'click .js-item-link'            : 'goToItemPage',
+    'click .js-rc-page'              : 'paginateRelatedCollections',
+    'click .js-relatedCollection'    : 'goToCollectionPage'
   },
   goToSearchResults: function(e) {
     this.model.unset('itemId', {silent: true});
@@ -417,6 +418,10 @@ var CarouselContext = Backbone.View.extend({
     });
   },
 
+  goToCollectionPage: function() {
+    this.model.clear();
+  },
+
   toJSON: function() {
     var context = this.model.toJSON();
     context.start = this.carouselStart;
@@ -496,7 +501,18 @@ var ComplexCarousel = Backbone.View.extend({
   },
 
   events: {
+    'click .js-set-link'        : 'getSet',
     'click .js-component-link'  : 'getComponent',
+  },
+  getSet: function(e) {
+    e.preventDefault();
+    $.pjax({
+      type: 'GET',
+      url: $(e.currentTarget).attr('href'),
+      container: '#js-itemContainer',
+      traditional: true,
+      scrollTo: 440
+    });
   },
   getComponent: function(e) {
     var data_params = {order: $(e.currentTarget).data('item_id')};

--- a/calisphere/templates/calisphere/collectionView.html
+++ b/calisphere/templates/calisphere/collectionView.html
@@ -33,7 +33,7 @@
         </span>
       {% else %}
         <div class="alert alert-warning" style="margin-top: 4px; padding: 5px;">
-          <p><i class="fa fa-exclamation-triangle"></i> Collection description needed. Do you own this collection? Please provide some information about this collection that will help Calisphere users understand and interpret the items in it. For examples of collection descriptions, browse other <a href="{% url 'calisphere:collectionsDirectory' %}" class="alert-link" style="text-decoration: underline;">collections</a>. <a href=“mailto: ucldc@ucop.edu” class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
+          <p><i class="fa fa-exclamation-triangle"></i> Collection description needed. Do you own this collection? Please provide some information about this collection that will help Calisphere users understand and interpret the items in it. For examples of collection descriptions, browse other <a href="{% url 'calisphere:collectionsDirectory' %}" class="alert-link" style="text-decoration: underline;" data-pjax="js-pageContent">collections</a>. <a href=“mailto: ucldc@ucop.edu” class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
         </div>
       {% endif %}
       {% if collection.url_local|length > 0 %}

--- a/calisphere/templates/calisphere/component-metadata.html
+++ b/calisphere/templates/calisphere/component-metadata.html
@@ -12,13 +12,13 @@
     
     <!-- should include institution name: UC Berkely, Bancroft Library -->
     <dt class="meta-block__type">Parent Item</dt>
-    <dd class="meta-block__defin"><a href="{% url 'calisphere:itemView' item.id %}">{{ item.title.0 }}</a></dd>
+    <dd class="meta-block__defin"><a href="{% url 'calisphere:itemView' item.id %}" data-pjax="js-pageContent">{{ item.title.0 }}</a></dd>
     
     {% if item.parsed_repository_data %}
       <dt class="meta-block__type">Contributing Institution</dt>
       <dd class="meta-block__defin">
         {% for repository in item.parsed_repository_data %}
-          <a href="{% url 'calisphere:repositoryView' repository.id 'collections' %}">
+          <a href="{% url 'calisphere:repositoryView' repository.id 'collections' %}" data-pjax="js-pageContent">
           {% if repository.campus %}
             {{ repository.campus }}, 
           {% endif %}
@@ -29,7 +29,7 @@
     
     {% if item.parsed_collection_data %}
       <dt class="meta-block__type">Collection</dt>
-      <dd class="meta-block__defin">{% for collection in item.parsed_collection_data %}<a href="{% url 'calisphere:collectionView' collection.id %}">{{ collection.name }}</a> <br> {% endfor %}</dd>
+      <dd class="meta-block__defin">{% for collection in item.parsed_collection_data %}<a href="{% url 'calisphere:collectionView' collection.id %}" data-pjax="js-pageContent" class="js-relatedCollection">{{ collection.name }}</a> <br> {% endfor %}</dd>
     {% endif %}
 
 </div>

--- a/calisphere/templates/calisphere/institutionView.html
+++ b/calisphere/templates/calisphere/institutionView.html
@@ -68,7 +68,7 @@
         <!-- </p> -->
         {% else %}
         <!-- <div class="alert alert-warning" style="margin: 20px;"> -->
-          <!-- <p><i class="fa fa-exclamation-triangle"></i> Campus description needed. We’ll be working with the Collection Administrator for this campus to develop this description. It will say something about the scope of institutions and distinctive collecting areas of the campus, and any other information that would be helpful for Calisphere users. For an example, see <a href="{% url 'calisphere:campusView' 'UCB' 'collections' %}" class="alert-link" style="text-decoration: underline;">UC Berkeley’s page</a>.</p> -->
+          <!-- <p><i class="fa fa-exclamation-triangle"></i> Campus description needed. We’ll be working with the Collection Administrator for this campus to develop this description. It will say something about the scope of institutions and distinctive collecting areas of the campus, and any other information that would be helpful for Calisphere users. For an example, see <a href="{% url 'calisphere:campusView' 'UCB' 'collections' %}" class="alert-link" style="text-decoration: underline;" data-pjax="js-pageContent">UC Berkeley’s page</a>.</p> -->
         <!-- </div> -->
         {% endif %}
 
@@ -102,7 +102,7 @@
           </p>
         {% else %}
         <div class="alert alert-warning" style="margin: 20px;">
-          <p><i class="fa fa-exclamation-triangle"></i> Institution description needed. Do you represent this institution? Please provide some information about its mission and/or collecting areas to help Calisphere users know what it’s all about. For examples of institution descriptions, browse other <a href="{% url 'calisphere:campusDirectory' %}" class="alert-link" style="text-decoration: underline;">institution pages</a>. <a href="mailto: ucldc@ucop.edu" class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
+          <p><i class="fa fa-exclamation-triangle"></i> Institution description needed. Do you represent this institution? Please provide some information about its mission and/or collecting areas to help Calisphere users know what it’s all about. For examples of institution descriptions, browse other <a href="{% url 'calisphere:campusDirectory' %}" class="alert-link" style="text-decoration: underline;" data-pjax="js-pageContent">institution pages</a>. <a href="mailto: ucldc@ucop.edu" class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
         </div>
         {% endif %}
       </div>
@@ -143,7 +143,7 @@
           </p>
         {% else %}
         <div class="alert alert-warning" style="margin: 20px;">
-          <p><i class="fa fa-exclamation-triangle"></i> Institution description needed. Do you represent this institution? Please provide some information about its mission and/or collecting areas to help Calisphere users know what it’s all about. For examples of institution descriptions, browse other <a href="{% url 'calisphere:statewideDirectory' %}" class="alert-link" style="text-decoration: underline;">institution pages</a>. <a href="mailto: ucldc@ucop.edu" class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
+          <p><i class="fa fa-exclamation-triangle"></i> Institution description needed. Do you represent this institution? Please provide some information about its mission and/or collecting areas to help Calisphere users know what it’s all about. For examples of institution descriptions, browse other <a href="{% url 'calisphere:statewideDirectory' %}" class="alert-link" style="text-decoration: underline;" data-pjax="js-pageContent">institution pages</a>. <a href="mailto: ucldc@ucop.edu" class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
         </div>
         {% endif %}
       </div>
@@ -176,7 +176,7 @@
           </p>
         {% else %}
         <div class="alert alert-warning" style="margin: 20px;">
-          <p><i class="fa fa-exclamation-triangle"></i> Institution description needed. Do you represent this institution? Please provide some information about its mission and/or collecting areas to help Calisphere users know what it’s all about. For examples of institution descriptions, browse other <a href="{% url 'calisphere:statewideDirectory' %}" class="alert-link" style="text-decoration: underline;">institution pages</a>. <a href="mailto: ucldc@ucop.edu" class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
+          <p><i class="fa fa-exclamation-triangle"></i> Institution description needed. Do you represent this institution? Please provide some information about its mission and/or collecting areas to help Calisphere users know what it’s all about. For examples of institution descriptions, browse other <a href="{% url 'calisphere:statewideDirectory' %}" class="alert-link" style="text-decoration: underline;" data-pjax="js-pageContent">institution pages</a>. <a href="mailto: ucldc@ucop.edu" class="alert-link" style="text-decoration: underline;">Email us</a> with copy or questions.</p>
         </div>
         {% endif %}
       </div>

--- a/calisphere/templates/calisphere/item.html
+++ b/calisphere/templates/calisphere/item.html
@@ -2,7 +2,7 @@
 
 <p class="text__breadcrumb-nav">
   {% if item.parsed_repository_data %}
-    <a href="{% url 'calisphere:repositoryView' item.parsed_repository_data.0.id 'collections' %}">
+    <a href="{% url 'calisphere:repositoryView' item.parsed_repository_data.0.id 'collections' %}" data-pjax="js-pageContent">
       {% if item.parsed_repository_data.0.campus %}
         {{ item.parsed_repository_data.0.campus }},
       {% endif %}
@@ -11,7 +11,7 @@
   {% endif %}
    >
   {% if item.parsed_collection_data %}
-     <a href="{% url 'calisphere:collectionView' item.parsed_collection_data.0.id %}">{{ item.parsed_collection_data.0.name }}</a>
+     <a href="{% url 'calisphere:collectionView' item.parsed_collection_data.0.id %}" data-pjax="js-pageContent" class="js-relatedCollection">{{ item.parsed_collection_data.0.name }}</a>
   {% endif %}
    > {{ item.title.0 }}
 </p>
@@ -56,7 +56,7 @@
     {% if item.structMap and item.selected == True %}
       Set Information.
     {% elif item.structMap %}
-      Page Information. <a href="{% url 'calisphere:itemView' item.id %}">Go to set information.</a>
+      Page Information. <a href="{% url 'calisphere:itemView' item.id %}" data-pjax="js-pageContent">Go to set information.</a>
     {% else %}
       Item Information.
     {% endif %}
@@ -101,7 +101,7 @@
       <dt class="meta-block__type">Contributing Institution</dt>
       <dd class="meta-block__defin">
         {% for repository in item.parsed_repository_data %}
-          <a href="{% url 'calisphere:repositoryView' repository.id 'collections' %}">
+          <a href="{% url 'calisphere:repositoryView' repository.id 'collections' %}" data-pjax="js-pageContent">
           {% if repository.campus %}
             {{ repository.campus }},
           {% endif %}
@@ -112,7 +112,7 @@
 
     {% if item.parsed_collection_data %}
       <dt class="meta-block__type">Collection</dt>
-      <dd class="meta-block__defin">{% for collection in item.parsed_collection_data %}<a href="{% url 'calisphere:collectionView' collection.id %}">{{ collection.name }}</a> <br> {% endfor %}</dd>
+      <dd class="meta-block__defin">{% for collection in item.parsed_collection_data %}<a href="{% url 'calisphere:collectionView' collection.id %}" data-pjax="js-pageContent" class="js-relatedCollection">{{ collection.name }}</a> <br> {% endfor %}</dd>
     {% endif %}
 
     {% if item.rights %}

--- a/calisphere/templates/calisphere/objectViewer/complex-object.html
+++ b/calisphere/templates/calisphere/objectViewer/complex-object.html
@@ -75,7 +75,7 @@
   <!--TODO: if {{ item.selected }} is True apply 'selected' styles -->
   <div class="carousel-complex__fixed-item">
     <a href="{% url 'calisphere:itemView' item.id %}" class="{% if item.selected %}carousel-complex__fixed-link--selected
-      {% else %}carousel-complex__fixed-link{% endif %}">
+      {% else %}carousel-complex__fixed-link{% endif %} js-set-link">
       <div class="carousel-complex__fixed-content">
       cover page
       </div>

--- a/calisphere/templates/calisphere/related-collections.html
+++ b/calisphere/templates/calisphere/related-collections.html
@@ -6,7 +6,7 @@
     {{ num_related_collections }} Collections in Search Results</h3>
   {% for related_collection in related_collections %}
     <div class="col-xs-12 col-sm-4">
-      <a class="related-coll__link" href="{% url 'calisphere:collectionView' related_collection.collection_id %}" data-pjax="js-pageContent">
+      <a class="related-coll__link js-relatedCollection" href="{% url 'calisphere:collectionView' related_collection.collection_id %}" data-pjax="js-pageContent">
         <div class="related-coll__container">
           <div class="col-xs-12 col-sm-12">
             

--- a/calisphere/templates/calisphere/related-collections.html
+++ b/calisphere/templates/calisphere/related-collections.html
@@ -11,72 +11,29 @@
           <div class="col-xs-12 col-sm-12">
             
             {% with related_collection.image_urls as items %}
-            <div class="related-coll__image1" style="position: relative;">
-              {% if items.0.type_ss.0|lower != "image" %}
-                {% if items.0.type_ss.0|lower == "moving image" %}
+            {% for item in items %}
+            <div class="related-coll__image{{ forloop.counter }}" style="position: relative;">
+              {% if item.type_ss.0|lower != "image" %}
+                {% if item.type_ss.0|lower == "moving image" %}
                 <span class="fa fa-play-circle-o fa-fw thumbview__icon-overlay"></span>
-                {% elif items.0.type_ss.0|lower == "sound"%}
+                {% elif item.type_ss.0|lower == "sound"%}
                 <span class="fa fa-volume-up fa-fw thumbview__icon-overlay"></span>
-                {% elif items.0.type_ss.0|lower == "text"%}
+                {% elif item.type_ss.0|lower == "text"%}
                 <span class="fa fa-file-text-o fa-fw thumbview__icon-overlay"></span>
                 {% elif item.type_ss.0|lower == "dataset" %}
                 <span class="fa fa-bar-chart fa-fw thumbview__icon-overlay"></span>
                 {% endif %}
               {% endif %}
-              {% if items.0.reference_image_md5 %}
+              {% if item.reference_image_md5 %}
                 <img style="width: 100%; height: 100%"
-                src="{{ thumbnailUrl }}crop/300x300/{{ items.0.reference_image_md5 }}"
-                
-                alt="{{ items.0.title.0|truncatewords:12 }}">
+                src="{{ thumbnailUrl }}crop/{% if forloop.counter == 1 %}300x300{% else %}200x200{% endif %}/{{ item.reference_image_md5 }}"
+                alt="{{ item.title.0|truncatewords:12 }}">
               {% else %}
-                <img src="{% static 'images/transparent.png' %}" alt="{{ items.0.title.0|truncatewords:12 }}" style="border: 1px solid #8b8d8e; width:100%; height:100%">
+                <img src="{% static 'images/transparent.png' %}" alt="{{ item.title.0|truncatewords:12 }}" style="border: 1px solid #8b8d8e; width:100%; height:100%">
               {% endif %}
             </div>
-            
-            <div class="related-coll__image2" style="position: relative;">
-              {% if items.1.type_ss.0|lower != "image" %}
-                {% if items.1.type_ss.0|lower == "moving image" %}
-                <span class="fa fa-play-circle-o fa-fw thumbview__icon-overlay"></span>
-                {% elif items.1.type_ss.0|lower == "sound"%}
-                <span class="fa fa-volume-up fa-fw thumbview__icon-overlay"></span>
-                {% elif items.1.type_ss.0|lower == "text"%}
-                <span class="fa fa-file-text-o fa-fw thumbview__icon-overlay"></span>
-                {% elif item.type_ss.0|lower == "dataset" %}
-                <span class="fa fa-bar-chart fa-fw thumbview__icon-overlay"></span>
-                {% endif %}
-              {% endif %}
-              {% if items.1.reference_image_md5 %}
-                <img style="width: 100%; height: 100%"
-                src="{{ thumbnailUrl }}crop/200x200/{{ items.1.reference_image_md5 }}"
-                
-                alt="{{ items.1.title.0|truncatewords:12 }}">
-              {% else %}
-                <img src="{% static 'images/transparent.png' %}" alt="{{ items.1.title.0|truncatewords:12 }}" style="border: 1px solid #8b8d8e; width:100%; height:100%">
-              {% endif %}
-            </div>
-            
-            <div class="related-coll__image3" style="position: relative;">
-              {% if items.2.type_ss.0|lower != "image" %}
-                {% if items.2.type_ss.0|lower == "moving image" %}
-                <span class="fa fa-play-circle-o fa-fw thumbview__icon-overlay"></span>
-                {% elif items.2.type_ss.0|lower == "sound"%}
-                <span class="fa fa-volume-up fa-fw thumbview__icon-overlay"></span>
-                {% elif items.2.type_ss.0|lower == "text"%}
-                <span class="fa fa-file-text-o fa-fw thumbview__icon-overlay"></span>
-                {% elif item.type_ss.0|lower == "dataset" %}
-                <span class="fa fa-bar-chart fa-fw thumbview__icon-overlay"></span>
-                {% endif %}
-              {% endif %}
-              {% if items.2.reference_image_md5 %}
-                <img style="width: 100%; height: 100%"
-                src="{{ thumbnailUrl }}crop/200x200/{{ items.2.reference_image_md5 }}"
-                
-                alt="{{ items.2.title.0|truncatewords:12 }}">
-              {% else %}
-                <img src="{% static 'images/transparent.png' %}" alt="{{ items.2.title.0|truncatewords:12 }}" style="border: 1px solid #8b8d8e; width:100%; height:100%">
-              {% endif %}
-            </div>
-            
+            {% endfor %}
+                        
             {% endwith %}            
           </div>
           <div class="col-xs-12 col-sm-12 related-coll__caption">

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -710,6 +710,7 @@ def statewideDirectory(request):
             if repository['name'][0] == char or repository['name'][0] == char.upper:
                 bin.append(repository)
         if len(bin) > 0:
+            bin.sort()
             binned_repositories.append({char: bin})
 
     return render(request, 'calisphere/statewideDirectory.html', {'state_repositories': binned_repositories})
@@ -934,6 +935,7 @@ def campusView(request, campus_slug, subnav=False):
 
         for i, related_institution in enumerate(related_institutions):
             related_institutions[i] = getRepositoryData(repository_data=related_institution)
+        related_institutions = sorted(related_institutions, key=lambda related_institution: related_institution['name'])
 
         return render(request, 'calisphere/institutionViewInstitutions.html', {
             'featuredImage': featured_image,


### PR DESCRIPTION
Cleared query manager object when clicking on a related collection link
Looped related collections thumbnails
Did a search for "<a" across all templates and added a data-pjax attribute where appropriate